### PR TITLE
Small fix in extracting number of events from MC dataset xml file

### DIFF
--- a/submit-jobs.py
+++ b/submit-jobs.py
@@ -52,7 +52,7 @@ def getFileList(filelist_xml):
  nevs_ = 0
  for l in f_filelist.readlines():
   if not '.root' in l:
-   nevs_ = int(l.split('"')[1])
+   nevs_ = int(float(l.split('"')[1]))
    continue
   list_.append(l.split('"')[1])
  return list_,nevs_


### PR DESCRIPTION
Small fix in extracting number of events from dataset xml file for MC. 
Converting a string representation of a `float` into `int` is not possible in python, and this fix mitigates this. 