### PR TITLE
added 2018 JEC V19 and JER-SF V7

### DIFF
--- a/src/UHHNtupleConverterModule.cxx
+++ b/src/UHHNtupleConverterModule.cxx
@@ -585,9 +585,9 @@ UHHNtupleConverterModule::UHHNtupleConverterModule(Context & ctx){
     }
     else if(year == Year::is2018 ){
       jec_tag = "Autumn18";
-      jec_ver = "8";
-      JER_sf  = JERSmearing::SF_13TeV_Autumn18_RunABCD_V4;
-      ResolutionFileName = "2018/Autumn18_V4_MC_PtResolution_AK4PFPuppi.txt";
+      jec_ver = "19";
+      JER_sf  = JERSmearing::SF_13TeV_Autumn18_V7;
+      ResolutionFileName = "2018/Autumn18_V7_MC_PtResolution_AK4PFPuppi.txt";
     }
     
     if(isMC){


### PR DESCRIPTION
Added latest 2018 JEC and JER-SF as described in https://hypernews.cern.ch/HyperNews/CMS/get/jes/898.html

In order for it to work it is necessary to pull from UHH for the merged PR  https://github.com/UHH2/UHH2/pull/1435  and `make` in the UHH directory